### PR TITLE
build: link arm64-macos binaries natively on darwin (clang/ld64, not zig)

### DIFF
--- a/support/compile-rust.nix
+++ b/support/compile-rust.nix
@@ -74,7 +74,12 @@ let
 		x86_64-linux = "x86_64-unknown-linux-gnu";
 	}.${target};
 
-	rust-pkg = import ./rust.nix args0;
+	# On a darwin host the arm64-macos target is native, so the native
+	# clang/ld64 toolchain links it correctly. zig is a cross-compiler whose
+	# 0.15.1 self-hosted MachO linker crashes (SIGABRT/SIGSEGV) on these
+	# links; skip the zig cargo wrapper on darwin and let cargo fall back to
+	# the native cc. zig stays in use for the linux cross targets.
+	rust-pkg = import ./rust.nix (args0 // { withZig = !pkgs.stdenv.hostPlatform.isDarwin; });
 in
 
 stdenv.mkDerivation (


### PR DESCRIPTION
## Summary

On an `aarch64-darwin` host, build the `arm64-macos` **binaries** (manager + executor) with the nix stdenv's native `clang`/`ld64` instead of zig.

The cargo wrapper forced **zig 0.15.1** as CC + linker for `aarch64-apple-darwin`, and zig's self-hosted MachO linker crashes with no diagnostic — **SIGABRT** on the `genvm-modules` link, **SIGSEGV** linking `zstd-sys`. On a darwin host the target is native, so `withZig = false` lets cargo use native `clang`/`ld64` (which also resolves macOS frameworks). zig stays for the linux cross targets.

Verified: `manager-arm64-macos` and `executor-arm64-macos` build and produce working native Mach-O arm64 binaries (`genvm-modules`/`genvm` run, `v0.3.0_rc2-aarch64-macos-release`).

## Scope

This PR is now **binaries only**. The earlier "build runners natively on darwin" commit was **dropped** per @kp2pml30's review — it broke the content-addressed-runner determinism invariant (darwin-built wasm differs from the canonical linux build under the same runner-id/filename, and some runner variants were missing). Building genvm runners from source on macOS is intentionally **out of scope** here; the focus stays on the binaries (and, separately, the node-side fee work).