### PR TITLE
feat(macos): native nix build (clang-wrapper linker) + QEMU runner builder

### DIFF
--- a/support/macos/nix-builder/Dockerfile
+++ b/support/macos/nix-builder/Dockerfile
@@ -2,6 +2,11 @@ FROM nixos/nix:2.32.8 AS base
 
 ENV PATH=/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/usr/local/bin:/usr/bin:/bin
 
+# Under emulated (foreign-arch) execution the seccomp BPF filter cannot be
+# loaded ("unable to load seccomp BPF program: Invalid argument"); disabling
+# the syscall filter is required for nix to build inside an emulated container.
+ENV NIX_CONFIG="filter-syscalls = false"
+
 RUN nix-env -iA --profile /nix/var/nix/profiles/default \
         nixpkgs.openssh \
         nixpkgs.python3 \

--- a/support/macos/nix-builder/README.md
+++ b/support/macos/nix-builder/README.md
@@ -1,7 +1,8 @@
 # nix-builder
 
 A Linux Nix remote builder reachable over SSH. Intended as a backing builder
-for a macOS host that wants to build Linux derivations.
+for a macOS host that wants to build Linux derivations (e.g. the genvm
+`runners-all`, whose wasm/cpython toolchain only builds on `x86_64-linux`).
 
 The container reads and writes a single volume mounted at
 `/var/lib/nix-builder`, which holds the server's host key and the authorized
@@ -14,26 +15,84 @@ that the Nix store is accessible — it does not need shell access beyond
 ## Prerequisites
 
 - macOS host on Apple Silicon (Apple-Silicon Mac mini / MacBook).
-- Rosetta installed system-wide:
-
-  ```sh
-  softwareupdate --install-rosetta --agree-to-license
-  ```
-
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (4.25+),
-  with **Settings → General → "Use Rosetta for x86_64/amd64 emulation on Apple
-  Silicon"** enabled. Foreign-arch (`x86_64-linux`) builds are dispatched by
-  the kernel's `binfmt_misc` to Rosetta; without it it may crash
 - Nix on the host (the connecting client). Tested with Nix `2.34.7`; older
   `2.2?.*` releases mishandle the `ssh-ng://host:port` form.
+- A Linux container runtime that can run `x86_64-linux`. Two options below —
+  **prefer colima + QEMU** (Option A) for building the runners; see the Rosetta
+  caveat.
 
-## Build
+### ⚠️ Rosetta caveat
+
+Docker Desktop's **"Use Rosetta for x86_64/amd64 emulation"** mangles
+versioned-symbol resolution for some x86_64 binaries. In particular the
+wasi-sdk `clang` dies with:
+
+```
+clang: symbol lookup error: …/wasi-sdk/bin/clang: undefined symbol: , version LLVM_22.1
+```
+
+(note the empty symbol name) when building the runners (`genvm-bz2` → cpython →
+wasm). This happens whether the container is arm64 (per-binary translation) or
+amd64 (whole-container Rosetta) — it's **Rosetta**, not the container arch. Use
+QEMU instead: either **Option A** below, or in Docker Desktop turn the Rosetta
+option off so it falls back to QEMU.
+
+## Option A — colima + QEMU (recommended)
+
+```sh
+brew install qemu lima-additional-guestagents colima
+
+colima start qemuamd64 --arch x86_64 --vm-type qemu --cpu 8 --memory 8
+# during iteration `colima delete qemuamd64` may be needed if it fails to start
+
+docker --context colima-qemuamd64 build -t nix-builder .
+
+docker --context colima-qemuamd64 run -d \
+    --name nix-builder --rm \
+    --privileged \
+    -p 2222:22 \
+    -v "$PWD/ssh:/var/lib/nix-builder" --cpus 8 --memory 10g \
+    nix-builder
+```
+
+The container runs as native `x86_64` inside the QEMU VM
+(`builtins.currentSystem == x86_64-linux`), so x86_64 builds never touch
+Rosetta.
+
+> **Bind-mount / ssh dir:** colima only mounts `$HOME` into its VM by default
+> (not `/tmp`). Run from a path under `$HOME`, or stage the `ssh/` dir under
+> `$HOME` (or add a colima `--mount`); otherwise the `-v "$PWD/ssh:…"` mount is
+> empty inside the VM and the container can't read `host.pub`.
+
+## Option B — Docker Desktop
+
+[Docker Desktop](https://www.docker.com/products/docker-desktop/) (4.25+).
+For x86_64 builds either enable QEMU (turn the Rosetta option **off** — see the
+caveat above) or accept that pure-Linux builds that don't exercise the wasi-sdk
+clang will work under Rosetta.
 
 ```sh
 docker build -t nix-builder .
-# potentially you need to add
-# --platform linux/arm64
+# on Apple Silicon you may need: --platform linux/amd64  (or linux/arm64)
+
+docker run -d \
+    --name nix-builder --rm \
+    --privileged \
+    -p 2222:22 \
+    -v "$PWD/ssh:/var/lib/nix-builder" \
+    nix-builder
 ```
+
+`--privileged` is needed for the nix sandbox.
+
+## Resources
+
+QEMU emulation is slow, and the runner builds (cpython / numpy / Pillow → wasm)
+are RAM-hungry. Give the VM real resources or the build will crawl / OOM:
+
+- colima VM: `--cpu 8 --memory 8` (reference values; `--cpu 6 --memory 12` also
+  works). The 2 CPU / 2 GiB colima default is not enough.
+- per-container caps on `docker run`: `--cpus 8 --memory 10g`.
 
 ## First run (bootstrap)
 
@@ -44,19 +103,6 @@ machine's `~/.ssh/id_ed25519.pub`) into the volume as `host.pub`:
 mkdir -p ./ssh
 cp ~/.ssh/id_ed25519.pub ./ssh/host.pub
 ```
-
-## Run
-
-```sh
-docker run -d \
-    --name nix-builder --rm \
-    --privileged \
-    -p 2222:22 \
-    -v "$PWD/ssh:/var/lib/nix-builder" \
-    nix-builder
-```
-
-Privileged is needed for sandboxing
 
 On startup the entrypoint:
 
@@ -72,8 +118,9 @@ Update `~/.ssh/known_hosts` with `ssh/id_ed25519.pub`:
 [localhost]:2222 ssh-ed25519 <key>
 ```
 
-> **Important:** you need to do it for root as well
-> you can ensure it via `sudo ssh -i /Users/rentamac/.ssh/id_ed25519 -p 2222 root@localhost true`
+> **Important:** you need to do it for root as well (the nix-daemon ssh's to the
+> builder as root). Ensure it via:
+> `sudo ssh -i ~/.ssh/id_ed25519 -p 2222 root@localhost true`
 
 ## Sanity check
 
@@ -106,9 +153,26 @@ Then enable remote builders in `/etc/nix/nix.conf`:
 builders-use-substitutes = true
 ```
 
+Now a host-side build of an `x86_64-linux` derivation (e.g.
+`nix build '.#runners-all'`) is dispatched to the container automatically.
+
+## Notes on the image config
+
+The image disables nix's seccomp syscall filter:
+
+- build-time via `ENV NIX_CONFIG="filter-syscalls = false"` in the `Dockerfile`,
+- runtime via `filter-syscalls = false` in `setup_nix_conf.py`.
+
+Under emulation nix can't load its seccomp BPF program
+(`error: unable to load seccomp BPF program: Invalid argument`), so the filter
+must be off. `setup_nix_conf.py` also sets `system` to the container's native
+arch, `extra-platforms` to the other Linux arch, and `cores = 0` (use all cores
+so the build isn't single-threaded).
+
 # Appendix
 
-For users unfamiliar with nix your `/etc/nix/nix.conf` should look something like this
+For users unfamiliar with nix your `/etc/nix/nix.conf` should look something
+like this:
 
 ```
 sandbox = true

--- a/support/macos/nix-builder/setup_nix_conf.py
+++ b/support/macos/nix-builder/setup_nix_conf.py
@@ -16,6 +16,8 @@ Path('/etc/nix/nix.conf').write_text(
 experimental-features = nix-command flakes
 sandbox = true
 sandbox-fallback = false
+filter-syscalls = false
+cores = 0
 build-users-group =
 system = {native}
 extra-platforms = {foreign}

--- a/support/rust.nix
+++ b/support/rust.nix
@@ -1,6 +1,6 @@
 { pkgs
 , deps
-, system ? "x86_64-linux"
+, system
 , withLinters ? false
 , withZig ? true
 , withWasi ? false
@@ -20,6 +20,8 @@ let
 		aarch64-linux = "arm64-linux";
 		aarch64-darwin = "arm64-macos";
 	}.${system};
+
+	is-macos = systemAsGenVM == "arm64-macos";
 
 	manifest-src = deps."rust-channel-stable-2026-03-05";
 
@@ -127,10 +129,10 @@ in pkgs.stdenvNoCC.mkDerivation rec {
 			--set CC_x86_64_unknown_linux_gnu zig-cc-amd64-linux-gnu \
 			--set CC_aarch64_unknown_linux_musl zig-cc-arm64-linux \
 			--set CC_aarch64_unknown_linux_gnu zig-cc-arm64-linux-gnu \
-			--set CC_aarch64_apple_darwin zig-cc-arm64-macos \
+			${if is-macos then "" else "--set CC_aarch64_apple_darwin zig-cc-arm64-macos"} \
 			--set CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER zig-cc-amd64-linux \
 			--set CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER zig-cc-arm64-linux \
-			--set CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER zig-cc-arm64-macos \
+			${if is-macos then "" else "--set CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER zig-cc-arm64-macos"} \
 			--set CC zig-cc-${systemAsGenVM} \
 			--set CARGO_LINKER zig-cc-${systemAsGenVM} \
 			--prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath buildInputs}"


### PR DESCRIPTION
## What

Make `nix build` of genvm work on Apple Silicon macOS.

**1. Native manager/executor link** (`support/rust.nix`)
On `aarch64-darwin`, drop the zig-cc linker override so the final rust link uses
the clang-wrapper from `.cargo/config.toml`. zig 0.15.1's self-hosted MachO
linker heap-corrupts when run natively on macOS — SIGSEGV in
`link.MachO.resolveSymbols → link.MachO.Object.deinit` (an invalid free in
`libsystem_malloc`) — which crashed `nix build .#manager-arm64-macos` /
`.#executor-arm64-macos` at the final link. The two darwin overrides are now
gated behind `is-macos`; zig stays the linker on Linux and remains the C
compiler (`CC`) everywhere. (zig 0.16.0 was tested too — same crash — so this
is not fixed by a zig bump.)

**2. nix-builder under emulation** (`support/macos/nix-builder/`)
Building the Linux-only runners (`.#runners-all`, wasm/cpython) needs a Linux
builder. Under emulation nix can't load its seccomp BPF filter
(`unable to load seccomp BPF program: Invalid argument`), so set
`filter-syscalls = false` (build-time via `NIX_CONFIG`, runtime via
`setup_nix_conf.py`) and `cores = 0` so the build isn't single-threaded. README
gains: the colima + QEMU flow, the **Rosetta caveat** (Docker Desktop's Rosetta
mangles the wasi-sdk clang's versioned symbols → `undefined symbol: , version
LLVM_22.1`; use QEMU instead), cpu/memory guidance, and the colima `$HOME`-mount
note.

## Tested — Apple M4 Pro, Determinate Nix 2.34.6

- `nix build .#manager-arm64-macos` ✅ and `.#executor-arm64-macos` ✅ — native, with the linker fix
- `nix build .#runners-all` ✅ — via a colima + QEMU `x86_64-linux` builder (6 CPU / 12 GiB)

The two changes are independent commits, so the linker fix can be split into its
own PR if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nix build failures that occurred when running under foreign-architecture emulation.

* **Documentation**
  * Expanded macOS Nix remote building setup documentation with updated prerequisites, colima and QEMU workflows, Rosetta compatibility notes, resource sizing guidance, and image configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->