### PR TITLE
test(fees): cover allocation tree emit trap gates

### DIFF
--- a/tests/cases/stable/py/intercontract/alloc_budget_exhausted.jsonnet
+++ b/tests/cases/stable/py/intercontract/alloc_budget_exhausted.jsonnet
@@ -1,0 +1,25 @@
+local simple_deploy = import 'templates/simple_deploy.jsonnet';
+local util = import 'templates/util.jsonnet';
+// A matching wildcard internal-finalized node, but budget=1 (< the computed
+// message_fee, which is ~34836 for foo(1,2) on finalized). The find_map matches,
+// then consume_message_fee_internal must trap on `fee_cost > node.budget`.
+// Mirrors origin/fees.py DEFAULT_INTERNAL_FIN_MESSAGE_ALLOC with budget lowered.
+{entry: util.addPaths([simple_deploy.run('${jsonnetDir}/${fileBaseName}.py') {
+	message_fee_allocation: [
+		{
+			budget: 1,
+			recipient: null,
+			call_key: null,
+			on: 'finalized',
+			fee_params: {
+				Internal: {
+					execution_budget_per_round: 1024,
+					rotations: [4, 4, 4, 4, 4],
+					leader_timeunits_allocation: 5,
+					validator_timeunits_allocation: 5,
+				},
+			},
+			children: [],
+		},
+	],
+}])}

--- a/tests/cases/stable/py/intercontract/alloc_budget_exhausted.py
+++ b/tests/cases/stable/py/intercontract/alloc_budget_exhausted.py
@@ -1,0 +1,16 @@
+# { "Depends": "py-genlayer:test" }
+import genlayer as gl
+from genlayer.types import *
+
+
+# Regression guard (genvm fee-allocation item #8): node MATCHES but its budget is
+# too small.
+#
+# Here the allocation tree has a matching wildcard internal-finalized node, so the
+# find_map succeeds, but its `budget` is below the computed message_fee. genvm must
+# hard-trap in consume_message_fee_internal ("message fee cost exceeds node budget"
+# -> oom_trap fees().internal()), never silently emit. This pins the second trap
+# gate (budget), distinct from the no-matching-node gate.
+class Contract(gl.contract.Contract):
+	def __init__(self):
+		gl.contract.get_at(gl.Address(b'\x30' * 20)).emit().foo(1, 2)

--- a/tests/cases/stable/py/intercontract/alloc_empty_deploy.jsonnet
+++ b/tests/cases/stable/py/intercontract/alloc_empty_deploy.jsonnet
@@ -1,0 +1,7 @@
+local simple_deploy = import 'templates/simple_deploy.jsonnet';
+local util = import 'templates/util.jsonnet';
+// Empty allocation tree => the DeployContract emit (matched by Address::zero() +
+// CallKey::DEPLOY) has no node and must hard-trap (OOM fees internal).
+{entry: util.addPaths([simple_deploy.run('${jsonnetDir}/${fileBaseName}.py') {
+	message_fee_allocation: [],
+}])}

--- a/tests/cases/stable/py/intercontract/alloc_empty_deploy.py
+++ b/tests/cases/stable/py/intercontract/alloc_empty_deploy.py
@@ -1,0 +1,16 @@
+# { "Depends": "py-genlayer:test" }
+import genlayer as gl
+from genlayer.types import *
+
+
+# Regression guard (genvm fee-allocation item #8): DeployContract variant.
+#
+# An empty message-fee-allocation tree must make a deploy emission hard-trap
+# (genlayer_sdk.rs DeployContract path: no matching node -> oom_trap fees().internal()),
+# never silently emit nothing.
+#
+# Paired positive case: ../intercontract/deploy.py (default tree -> DeployContract
+# emission succeeds).
+class Contract(gl.contract.Contract):
+	def __init__(self):
+		gl.contract.deploy(code='not really a contract'.encode('utf-8'))

--- a/tests/cases/stable/py/intercontract/alloc_empty_eth_send.jsonnet
+++ b/tests/cases/stable/py/intercontract/alloc_empty_eth_send.jsonnet
@@ -1,0 +1,7 @@
+local simple_deploy = import 'templates/simple_deploy.jsonnet';
+local util = import 'templates/util.jsonnet';
+// Empty allocation tree => the external EthSend has no matching node and must
+// hard-trap (OOM fees external).
+{entry: util.addPaths([simple_deploy.run('${jsonnetDir}/${fileBaseName}.py') {
+	message_fee_allocation: [],
+}])}

--- a/tests/cases/stable/py/intercontract/alloc_empty_eth_send.py
+++ b/tests/cases/stable/py/intercontract/alloc_empty_eth_send.py
@@ -1,0 +1,27 @@
+# { "Depends": "py-genlayer:test" }
+import genlayer as gl
+from genlayer.types import *
+
+
+# Regression guard (genvm fee-allocation item #8): EthSend (external) variant.
+#
+# An empty message-fee-allocation tree must make an external (eth) send hard-trap
+# (genlayer_sdk.rs EthSend path: no matching node -> oom_trap fees().external()),
+# never silently emit nothing. The balance check (value=30 <= 100) passes first,
+# so the trap comes from the allocation lookup, not from balance.
+#
+# Paired positive case: ../intercontract/send_message_eth.py (default tree ->
+# EthSend emission succeeds).
+@gl.evm.contract_interface
+class Ghost:
+	class View:
+		pass
+
+	class Write:
+		def test(self, x: u256, /) -> None: ...
+
+
+class Contract(gl.contract.Contract):
+	def __init__(self):
+		print(self.balance)
+		Ghost(Address(b'\x30' * 20)).emit(value=30).test(10)

--- a/tests/cases/stable/py/intercontract/alloc_empty_post_message.jsonnet
+++ b/tests/cases/stable/py/intercontract/alloc_empty_post_message.jsonnet
@@ -1,0 +1,8 @@
+local simple_deploy = import 'templates/simple_deploy.jsonnet';
+local util = import 'templates/util.jsonnet';
+// Empty message-fee-allocation tree => the PostMessage emit has no matching node
+// and must hard-trap (OOM fees internal). Overrides the runner default of three
+// wildcard catch-all nodes (origin/fees.py DEFAULT_*_MESSAGE_ALLOC).
+{entry: util.addPaths([simple_deploy.run('${jsonnetDir}/${fileBaseName}.py') {
+	message_fee_allocation: [],
+}])}

--- a/tests/cases/stable/py/intercontract/alloc_empty_post_message.py
+++ b/tests/cases/stable/py/intercontract/alloc_empty_post_message.py
@@ -1,0 +1,19 @@
+# { "Depends": "py-genlayer:test" }
+import genlayer as gl
+from genlayer.types import *
+
+
+# Regression guard (genvm fee-allocation item #8).
+#
+# genvm is a pure CONSUMER of the message-fee-allocation tree the node provides.
+# With an EMPTY tree, emitting an internal message MUST hard-trap (the find_map
+# in genlayer_sdk.rs finds no matching node -> `oom_trap(... .fees().internal())`),
+# it must NEVER silently emit nothing. A silent-0 here was the exact symptom of
+# the consensus/node DisallowedFeeAllocation([]) bug investigated cross-repo; this
+# test pins genvm's side so it can't regress to "0 emissions, no error".
+#
+# Paired positive case: ../intercontract/send_message.py (default wildcard tree
+# -> the same emit succeeds with a PostMessage emission).
+class Contract(gl.contract.Contract):
+	def __init__(self):
+		gl.contract.get_at(gl.Address(b'\x30' * 20)).emit().foo(1, 2)


### PR DESCRIPTION
## Description

Adds four `intercontract` integration cases pinning genvm's behavior when the node-provided message-fee-allocation tree cannot fund an emitted message. genvm is a pure consumer of this tree (`executor/src/wasi/genlayer_sdk.rs`); when no matching node exists or its budget is too small, an emit must hard-trap, never silently produce zero emissions.

These guard the genvm side of a cross-repo issue where an empty allocation tree (the node's `DisallowedFeeAllocation([])` fallback, returned when the deployed consensus provisioned nothing) led to zero internal messages while the parent still finalized. Root cause is consensus/node; this locks genvm so a silent-zero cannot regress here.

## Tests

- `alloc_empty_post_message` — empty tree, PostMessage emit must trap (OOM fees internal)
- `alloc_empty_deploy` — empty tree, DeployContract emit must trap
- `alloc_empty_eth_send` — empty tree, external EthSend must trap (OOM fees external); the balance check passes first, so the trap comes from the allocation lookup
- `alloc_budget_exhausted` — a matching wildcard node but `budget` below the computed message fee, must trap on the budget gate

The positive direction (populated wildcard tree -> emission succeeds) is already covered by the existing `send_message` / `deploy` / `send_message_eth` cases.

## Golden files

The `.stdout` / `.hash` expected files are intentionally not included. The runner auto-blesses them on first run, but the nix test shell only instantiates on Linux (it pulls glibc), so they must be generated on Linux/CI. Run the four `alloc_*` cases once on Linux and commit the blessed goldens.

Test-only change; no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test cases covering message fee allocation scenarios, including budget exhaustion, empty allocations for deployments, external ETH transfers, and internal post-message operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->