### PR TITLE
fix(build): repoint frozen gen-00 zlib fetch to genvm-artifacts mirror

### DIFF
--- a/runners/support/versions/all.nix
+++ b/runners/support/versions/all.nix
@@ -2,6 +2,6 @@
 , ...
 }@args:
 let
-	gen-00 = import ./generation-00.nix { repo = build-config.repo-url; };
+	gen-00 = import ./generation-00.nix { repo = build-config.repo-url; inherit (args) pkgs; };
 	head = import ./head.nix args;
 in gen-00 ++ head

--- a/runners/support/versions/generation-00.nix
+++ b/runners/support/versions/generation-00.nix
@@ -1,4 +1,5 @@
 { repo ? "https://github.com/genlayerlabs/genvm.git"
+, pkgs
 , ...
 }:
 let
@@ -7,6 +8,48 @@ let
 		"de381dbc862575b2a4f3d43a1b96ec14814af9fd" # v0.2.3
 		"fed444c0d9537f41a6ccafeac7c7507a2cd8f69e" # v0.2.4
 	];
+
+	# These frozen v0.2.x runner trees hardcode the upstream zlib tarball URL in
+	# runners/cpython/deps/zlib.nix with NO mirror. The current ("head") recipe
+	# fetches the SAME genvm-zlib-src output (identical name + sha256, via
+	# dependency-urls.json) but with a mirror list — so both produce the same
+	# /nix/store output path through two different .drvs. nix realizes only one of
+	# them, non-deterministically: pick the head .drv and the dead zlib.net URL
+	# falls back to the GCS mirror and builds; pick this frozen .drv and there is
+	# no mirror, so it 404s and the whole runners-all build fails (~50% of
+	# from-source CI builds). zlib.net moved 1.3.1 under /fossils/, hence the 404.
+	# We rewrite the dead URL to the genvm-artifacts GCS mirror — the same artifact
+	# the head recipe already falls back to, which we control — in a copy of the
+	# fetched tree before importing it, so BOTH .drvs are resilient regardless of
+	# which one nix schedules. fetchzip is content-addressed by its sha256, so the
+	# genvm-zlib-src output path (and every downstream runner output hash) is
+	# unchanged; only the source URL changes. The grep guard fails loudly if a rev
+	# no longer carries the expected dead URL, so this never silently no-ops.
+	#
+	# IMPORTANT: --preserve=mode + a content-only rewrite of zlib.nix. The frozen
+	# trees ship executable build scripts (e.g. numpy's deps/stub-clang.py, 0755);
+	# a blanket `cp --no-preserve=mode` strips those bits and the numpy configure
+	# phase dies with exit 126 (Permission denied). So we keep every file's mode
+	# and touch ONLY zlib.nix's contents — the rest of the tree stays byte- and
+	# mode-identical, so downstream runner FOD outputs match their pinned hashes.
+	patchOldSrc = rev: src:
+		pkgs.runCommandLocal
+			"genvm-runners-src-${builtins.substring 0 12 rev}-zlib-mirror"
+			{ }
+			''
+				cp -r --preserve=mode ${src} "$out"
+				zlibNix="$out/runners/cpython/deps/zlib.nix"
+				if ! grep -q 'https://www.zlib.net/zlib-1.3.1.tar.gz' "$zlibNix"; then
+					echo "generation-00 zlib patch: expected dead URL not found in $zlibNix (rev ${rev}); patch is stale" >&2
+					exit 1
+				fi
+				chmod u+w "$zlibNix"
+				tmp="$(mktemp)"
+				sed 's|https://www.zlib.net/zlib-1.3.1.tar.gz|https://storage.googleapis.com/genvm-artifacts/zlib-1.3.1.tar.gz|g' \
+					"$zlibNix" > "$tmp"
+				cat "$tmp" > "$zlibNix"
+				rm -f "$tmp"
+			'';
 
 	mapRev = rev:
 		let
@@ -17,8 +60,9 @@ let
 				shallow = true;
 				submodules = true;
 			};
+			patchedSrc = patchOldSrc rev src;
 		in
-			builtins.map (x: x // { inherit rev; }) (import "${src}/runners")
+			builtins.map (x: x // { inherit rev; }) (import "${patchedSrc}/runners")
 		;
 in
 	# list[{id, hash, rev, derivation}]


### PR DESCRIPTION
## Problem

`nix build .#runners-all` intermittently fails (~50% of from-source CI builds) with:

```
genvm-zlib-src> trying https://www.zlib.net/zlib-1.3.1.tar.gz
genvm-zlib-src> curl: (22) The requested URL returned error: 404
genvm-zlib-src> error: cannot download genvm-zlib-src from any mirror
```

### Root cause

`all.nix` builds `gen-00` (frozen historical v0.2.0 / v0.2.3 / v0.2.4 runner trees). Those predate the `dependency-urls.json` mirror system, so their `runners/cpython/deps/zlib.nix` hardcodes `https://www.zlib.net/zlib-1.3.1.tar.gz` with **no** mirror. zlib.net moved 1.3.1 to `/fossils/`, so that URL now 404s.

The current ("head") recipe fetches the **same** `genvm-zlib-src` output (identical name + sha256) but **with** a mirror list — so both produce the same `/nix/store` output path through two different `.drv`s. nix realizes only one, non-deterministically:

- picks **head** (`urls = [zlib.net, GCS]`) → 404 → GCS fallback → ✅
- picks **frozen** (`urls = [zlib.net]`) → 404, no fallback → ❌

…hence the ~50% coin-flip. (Not a cache/store issue — the runner image carries no genvm paths; every runner builds zlib fresh.)

Failing run: https://github.com/genlayerlabs/genlayer-e2e/actions/runs/27702462350 — blocks genlayer-node #1468.

## Fix

In `generation-00.nix`, rewrite the dead URL in each fetched frozen rev's `zlib.nix` to the **`genvm-artifacts` GCS mirror** (head's own fallback, which we control) before importing. Both `.drv`s become resilient → green regardless of which nix schedules. `fetchzip` is sha256-addressed, so the `genvm-zlib-src` output path and all downstream v0.2.x runner hashes are **unchanged**. A `grep` guard fails loudly if a rev no longer carries the expected dead URL. `all.nix` threads `pkgs` through (its only caller).

## Verification

- ✅ `nix-instantiate --parse` clean.
- ⏳ Build-verify is **statistical**: a single green run isn't proof (nix may keep picking the already-resilient head recipe). genlayer-e2e is running several `Depends-On: genlayerlabs/genvm@fix/gen00-zlib-dead-url` builds — expect 0 failures vs ~50% today.
- Not buildable on macOS (deterministic runner-FOD invariant); verified on linux.

## Known follow-up (not in this PR)

The other ~11 hardcoded, un-mirrored URLs in the frozen gen-00 trees (bz2, ffi, xz, wasi-sdk, numpy/pil git, …) are latent rot risks with the same failure mode — zlib is just the first to die. Consider dropping gen-00 if v0.2.x runners aren't needed, or a persistent genvm nix substituter, as a structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated runner version generation to properly manage package dependencies across build configuration layers.
  * Enhanced source tree processing to redirect external dependency downloads to controlled internal mirrors.
  * Improves build reliability and consistency with centralized control over dependency artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->