### PR TITLE
fix: check empty leader nondet result before indexing data[0]

### DIFF
--- a/executor/src/wasi/genlayer_sdk.rs
+++ b/executor/src/wasi/genlayer_sdk.rs
@@ -1301,6 +1301,11 @@ impl ContextVFS<'_> {
             }
             Some(data) => {
                 use crate::public_abi::ResultCode;
+                if data.is_empty() {
+                    return Err(generated::types::Error::trap(
+                        crate::anyhow_to_wasmtime(anyhow::anyhow!("leader nondet result is empty"))
+                    ));
+                }
                 let rest = &data[1..];
                 let res = match data[0] {
                     x if x == ResultCode::Return as u8 => rt::vm::RunOk::Return(rest.into()),


### PR DESCRIPTION
## Summary

Fixes index-out-of-bounds panic when a malicious leader injects `Bytes::new()` as a nondet result.

## Root Cause

In `executor/src/wasi/genlayer_sdk.rs` ~L1305, inside `leader_nondet_results` handling:

```rust
Some(data) => {
    let rest = &data[1..]; // panics if data.is_empty()
    let res = match data[0] { // index OOB if data is empty
```

`data` arrives from the wire via `calldata::decode_obj` with no per-element length validation. A malicious leader can inject `Bytes::new()` (empty bytes), causing `data[0]` to panic and crashing the validator.

## Impact

Consensus liveness compromised — validator crashes on empty nondet result, preventing finalization.

## Fix

Added `data.is_empty()` check before `data[0]` access, returning a proper error instead of panicking.

## PoC

https://github.com/lau90eth/genvm-nondet-panic

## Related

Finding originally submitted to GenLayer Builders Program portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for leader nondeterministic results to prevent empty values from being processed.
  * Users now receive a clear error if a result is missing expected bytes, reducing unexpected runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->