### PR TITLE
fix: limit Vec::with_capacity in binary calldata decoder to prevent OOM

### DIFF
--- a/executor/crates/calldata/src/bin.rs
+++ b/executor/crates/calldata/src/bin.rs
@@ -210,6 +210,10 @@ impl Parser<'_> {
                     if full_size == 0 {
                         Value::Array(Vec::new())
                     } else {
+                        const MAX_ARRAY_CAPACITY: usize = 1024 * 1024; // 1M elements max
+                        if full_size > MAX_ARRAY_CAPACITY {
+                            return Err(anyhow::anyhow!("array capacity too large: {}", full_size));
+                        }
                         stack.push(Frame::Array {
                             collected: Vec::with_capacity(full_size),
                             remaining: full_size,

--- a/executor/src/wasi/genlayer_sdk.rs
+++ b/executor/src/wasi/genlayer_sdk.rs
@@ -1301,6 +1301,11 @@ impl ContextVFS<'_> {
             }
             Some(data) => {
                 use crate::public_abi::ResultCode;
+                if data.is_empty() {
+                    return Err(generated::types::Error::trap(
+                        crate::anyhow_to_wasmtime(anyhow::anyhow!("leader nondet result is empty"))
+                    ));
+                }
                 let rest = &data[1..];
                 let res = match data[0] {
                     x if x == ResultCode::Return as u8 => rt::vm::RunOk::Return(rest.into()),


### PR DESCRIPTION
## Summary

Adds a maximum capacity guard in the binary calldata decoder to prevent OOM allocation via malicious input.

## Root Cause

In `executor/crates/calldata/src/bin.rs:214`, `Vec::with_capacity(full_size)` is called where `full_size` comes directly from untrusted wire data with no upper bound check:

```rust
stack.push(Frame::Array {
    collected: Vec::with_capacity(full_size), // OOM if full_size is huge
    remaining: full_size,
});
```

A malicious calldata packet can set the array size field to a large value (e.g. `0xFFFFFFFF`), causing the allocator to attempt a multi-GB allocation and crash the validator process.

## Impact

Validator OOM crash — consensus liveness compromised. Introduced in commit 699ec88 (`feat: add limit to calldata parsing`) which rewrote the decoder in `bin.rs` without carrying over the original bounds check from `de.rs`.

## Fix

Added `MAX_ARRAY_CAPACITY = 1024 * 1024` guard before `Vec::with_capacity`, returning an error for oversized arrays.

## PoC

https://github.com/lau90eth/genvm-bin-oom

## Related

Finding originally submitted to GenLayer Builders Program portal.