### PR TITLE
fix(modules): platform-check existing executor in post-install 🐛🔒️

### DIFF
--- a/modules/install/lib/python/post-install/__main__.py
+++ b/modules/install/lib/python/post-install/__main__.py
@@ -528,7 +528,7 @@ def process_executor_version(executor_version: str):
 		major, minor, patch = parse_executor_version(executor_version)
 		if (major, minor, patch + 1) in all_executor_version_tuples:
 			logger.info(
-				f'Skipping executor version {executor_version} because a newer version {next_version} exists'
+				f'Skipping executor version {executor_version} because a newer version v{major}.{minor}.{patch + 1} exists'
 			)
 			return
 

--- a/modules/install/lib/python/post-install/__main__.py
+++ b/modules/install/lib/python/post-install/__main__.py
@@ -3,6 +3,8 @@ import os
 import shlex
 import argparse
 import platform
+import shutil
+import struct
 import tarfile
 import io
 import traceback
@@ -491,6 +493,34 @@ for v in all_executor_versions:
 		all_executor_version_tuples.add(parse_executor_version(v))
 
 
+_ELF_MACHINE_TO_ARCH = {0x3E: 'amd64', 0xB7: 'arm64'}
+_MACHO_CPUTYPE_TO_ARCH = {0x01000007: 'amd64', 0x0100000C: 'arm64'}
+
+
+def detect_executable_platform(path: Path) -> tuple[str, str] | None:
+	"""Detect (os, arch) of an executable from magic bytes, e.g. ('linux', 'amd64').
+
+	Returns None if the file is not a recognized ELF or 64-bit Mach-O binary,
+	or its architecture is not one we distribute (amd64/arm64).
+	"""
+	with open(path, 'rb') as f:
+		header = f.read(20)
+	if len(header) < 20:
+		return None
+	if header[:4] == b'\x7fELF':
+		endian = '>' if header[5] == 2 else '<'
+		(e_machine,) = struct.unpack_from(endian + 'H', header, 18)
+		arch = _ELF_MACHINE_TO_ARCH.get(e_machine)
+		return ('linux', arch) if arch else None
+	(magic,) = struct.unpack_from('<I', header, 0)
+	if magic in (0xFEEDFACF, 0xCFFAEDFE):
+		endian = '<' if magic == 0xFEEDFACF else '>'
+		(cputype,) = struct.unpack_from(endian + 'I', header, 4)
+		arch = _MACHO_CPUTYPE_TO_ARCH.get(cputype)
+		return ('macos', arch) if arch else None
+	return None
+
+
 def process_executor_version(executor_version: str):
 	logger.info(f'Examining executor version {executor_version}')
 
@@ -506,6 +536,27 @@ def process_executor_version(executor_version: str):
 	executor_executable = executor_root_dir.joinpath('bin', 'genvm')
 
 	if args.executor_download or args.bin_patch or args.bin_check:
+		if executor_executable.exists():
+			found = detect_executable_platform(executor_executable)
+			expected = (args.os, args.arch)
+			if found != expected:
+				found_str = f'{found[0]}/{found[1]}' if found else 'unrecognized binary format'
+				mismatch_msg = (
+					f'Existing executor {executor_executable} does not match the target platform: '
+					f'found {found_str}, expected {expected[0]}/{expected[1]}'
+				)
+				if args.executor_download:
+					logger.warning(
+						f'{mismatch_msg}; removing {executor_root_dir} and re-downloading'
+					)
+					shutil.rmtree(executor_root_dir)
+				else:
+					logger.error(mismatch_msg)
+					raise RuntimeError(
+						mismatch_msg
+						+ ' (enable the executor-download step to replace it, or remove '
+						+ f'{executor_root_dir} manually)'
+					)
 		if not executor_executable.exists() and args.executor_download:
 			import lzma
 


### PR DESCRIPTION
## Summary

Field incident (2026-07-09): a genlayer-node linux-amd64 release tarball shipped a **Mach-O arm64** genvm executor. Post-install's `process_executor_version()` only downloads the executor when the binary is *absent*, so it accepted the wrong-platform binary, LIEF-patched it in place, and the failure only surfaced at runtime as an opaque `Exec format error`. Forcing `--executor-download true` could not fix it.

This hardens the consumer side so a wrong executor is caught at install time regardless of who put it there (the producer bug — host-defaulted `--os/--arch` in genlayer-node's `download_genvm.sh` — is already fixed in genlayer-node#1540):

- New dependency-free `detect_executable_platform()`: sniffs the first 20 bytes — ELF `e_machine` (0x3E → amd64, 0xB7 → arm64) and 64-bit Mach-O magic + `cputype` (x86_64/arm64), both endiannesses. Unrecognized format/arch counts as a mismatch (a real executor is always a thin ELF/Mach-O).
- An **existing** `executor/<version>/bin/genvm` is now checked against `--os`/`--arch` before being trusted:
  - mismatch + download enabled → warn (`found macos/arm64, expected linux/amd64`), delete the poisoned version tree, fall through to the normal re-download (self-healing);
  - mismatch + download disabled → `RuntimeError` at install time with found-vs-expected platforms and a remediation hint;
  - match → untouched, proceeds as before.
- Drive-by (second commit): the skip-newer-version log line referenced an undefined `next_version` — a latent `NameError` whenever a manifest lists two adjacent patch versions.

## Verification

- Detector unit-tested against crafted headers (both ELF arches, both Mach-O arches and byte orders, RISC-V ELF, shell script, truncated, empty) plus a real arm64 Mach-O binary — 10/10.
- End-to-end repro of the incident: fake bundle tree with a Mach-O arm64 planted at `executor/v0.0.1/bin/genvm`, targeting linux/amd64, release tarball served via `file://`:
  - download disabled → exit 1 with the full diagnostic;
  - download enabled → warns, deletes, re-downloads; healed binary verified ELF/amd64;
  - correct binary already present → untouched, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)