### PR TITLE
fix(modules): make bin-patch skip runnable binaries, prefer patchelf 🐛

### DIFF
--- a/modules/install/lib/python/post-install/__main__.py
+++ b/modules/install/lib/python/post-install/__main__.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import argparse
 import platform
+import shutil
 import tarfile
 import io
 import traceback
@@ -167,11 +168,6 @@ import json
 
 logging.info('Starting actual post-install script')
 
-if args.bin_patch:
-	import lief
-
-	lief.logging.set_level(lief.logging.LEVEL.ERROR)
-
 HASH_VALID_CHARS = '0123456789abcdfghijklmnpqrsvwxyz'
 
 
@@ -220,16 +216,101 @@ def get_interpreter_path():
 	return interpreter_path
 
 
+def executable_runs_unpatched(path: Path) -> bool:
+	"""Whether the binary already executes on this machine.
+
+	If it does, the loader resolved its interpreter and every needed library, so
+	there is nothing to patch. Skipping in that case avoids rewriting a ~300MB
+	ELF (a multi-GB memory spike in lief) and keeps re-runs idempotent: a binary
+	patched by a previous run stays untouched, which matters because lief cannot
+	re-parse its own output.
+	"""
+	env = os.environ.copy()
+	env['LLVM_PROFILE_FILE'] = '/dev/null'
+	try:
+		res = subprocess.run(
+			[path, '--version'],
+			capture_output=True,
+			timeout=60,
+			env=env,
+		)
+	except Exception as e:
+		logger.info(f'{path} does not run unpatched ({e})')
+		return False
+	if res.returncode != 0:
+		logger.info(f'{path} exited with {res.returncode} unpatched')
+		return False
+	return True
+
+
+def patch_executable_patchelf(path: Path, *, rpath_dir: list[Path]) -> None:
+	"""Apply the same interpreter/rpath changes as the lief path via patchelf.
+
+	patchelf edits in place: no full-file rewrite (lief needs a working set many
+	times the binary size) and no section-header corruption (lief output is
+	rejected by readelf/patchelf).
+	"""
+	interp = subprocess.run(
+		['patchelf', '--print-interpreter', path],
+		capture_output=True,
+		text=True,
+		check=True,
+	).stdout.strip()
+	logger.info(f'Current interpreter: {interp}')
+
+	if Path(interp).exists():
+		logger.info(f'Interpreter {interp} exists, skipping interpreter patching')
+	else:
+		new_interpreter = str(get_interpreter_path())
+		subprocess.run(
+			['patchelf', '--set-interpreter', new_interpreter, path], check=True
+		)
+		logger.info(f'Updated interpreter from {interp} to: {new_interpreter}')
+
+	# --force-rpath sets DT_RPATH, matching what the lief path writes
+	rpath_str = ':'.join(str(rpath) for rpath in rpath_dir)
+	subprocess.run(
+		['patchelf', '--force-rpath', '--set-rpath', rpath_str, path], check=True
+	)
+	logger.info(f'Set RPATH via patchelf: "{rpath_str}"')
+
+
 def patch_executable(path: Path, *, rpath_dir: list[Path]):
 	logger.info(f'Patching executable for {path}')
 	if not path.exists():
 		logger.warning(f'Path {path} does not exist, skipping patching')
 		return
 
+	if (args.os, args.arch) == (target_os, target_arch):
+		if executable_runs_unpatched(path):
+			logger.info(f'{path} already runs unpatched, skipping patching')
+			return
+
+	with open(path, 'rb') as f:
+		is_elf = f.read(4) == b'\x7fELF'
+
+	if is_elf and shutil.which('patchelf'):
+		try:
+			patch_executable_patchelf(path, rpath_dir=rpath_dir)
+			return
+		except subprocess.CalledProcessError as e:
+			logger.warning(
+				f'patchelf failed on {path} ({e}), falling back to lief; '
+				f'note the lief writer needs memory several times the binary size'
+			)
+
+	# deferred: lief is only needed when a rewrite is actually performed
+	import lief
+
+	lief.logging.set_level(lief.logging.LEVEL.ERROR)
+
 	binary = lief.parse(path)
 	if not binary:
-		logger.error(f'Failed to parse binary at {path}')
-		return
+		raise RuntimeError(
+			f'Failed to parse binary at {path}. If it was patched by a previous '
+			f'run, lief cannot re-parse its own output: delete the tree and '
+			f're-run with the executor-download step, or install patchelf'
+		)
 
 	# Log basic binary information
 	logger.info(f'Binary format: {binary.format}')


### PR DESCRIPTION
## Summary

Field report from the pre-clarke validator launch (2026-07-10): three distinct failures in post-install's `patch_executable()`, all stemming from LIEF's full-file rewrite of the ~291MB executor just to set an RPATH:

1. `binary.write()` needs a working set several times the binary size — `std::bad_alloc` on a box with 18GB free.
2. Re-runs after any partial failure wedge: LIEF cannot re-parse an ELF it wrote itself.
3. The rewritten ELF has corrupt section headers — it runs (the loader only uses program headers), but `readelf` errors out and `patchelf` refuses the file, so downstream tooling (stripping, signing, scanners) chokes.

## Fix

Patching only ever sets interpreter/rpath, so ask the ground-truth question first: **when the target platform matches the host, exec `<binary> --version` (60s timeout) before doing anything.** Exit 0 means the loader resolved the interpreter and every needed library — skip patching entirely. This fixes all three issues for standard (FHS) deploys, where the shipped tree's interpreter resolves and `$ORIGIN/../lib` RUNPATH already works, and makes re-runs idempotent: a binary patched by a previous run executes and is skipped, so LIEF never re-parses its own output. (A static "is `$ORIGIN/../lib` present" check — the field report's suggestion — would not have sufficed: the code sets two rpath dirs and `$ORIGIN/../lib` covers only one, so dir-coverage would still "need" patching on every FHS box.)

When patching is genuinely needed (e.g. NixOS-style hosts where the interpreter doesn't resolve):

- **Prefer `patchelf`** when the file is ELF and the CLI is on PATH: `--print-interpreter`, `--set-interpreter` only if the current one doesn't resolve (same rule as before), and `--force-rpath --set-rpath` (DT_RPATH, parity with what the LIEF path writes). In-place edit — no memory multiplier, output stays valid for section-parsing tools.
- **LIEF demoted to last resort**: its import is deferred to the actual rewrite path (it no longer loads at all when patching is skipped or patchelf handles it — also easing the NixOS `libstdc++.so.6` venv quirk), and a parse failure now raises with a recovery hint instead of the previous silent `return` that shipped a possibly-unpatched binary.

## Verification

E2E against the real script on three fake bundle trees:

- runnable stand-in binaries at host platform → both `bin/genvm-modules` and `executor/<v>/bin/genvm` skipped, exit 0, and LIEF provably never imported (the test python has no lief installed);
- non-runnable non-ELF, no patchelf → falls through to the LIEF import in the expected order;
- fake ELFs, cross-target (host-exec gate bypassed as designed) with a logging `patchelf` stub on PATH → argv exactly `--print-interpreter` then `--force-rpath --set-rpath <root>/lib[:<exec>/lib]` per binary, no `--set-interpreter` (stub interpreter resolves), no LIEF.

Known limit: the patchelf path was validated against a stub (no linux-ELF + patchelf pair on this dev machine); a real NixOS smoke-run of `setup.py` is being arranged via the dev-env team once this lands in an rc.

Merges cleanly on top of #323 — different regions of the same file; both add `import shutil`. In the step flow, #323's platform check runs before this precheck, so a wrong-platform binary is deleted/re-downloaded before anything asks whether it "runs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)