### PR TITLE
docs: fix Event docstring examples to gl.chain.Event

### DIFF
--- a/runners/genlayer-py-std/src/genlayer/chain.py
+++ b/runners/genlayer-py-std/src/genlayer/chain.py
@@ -100,11 +100,11 @@ class Event:
 	"""
 	.. code-block:: python
 
-	        class TransferOccurredEvent(gl.Event):
+	        class TransferOccurredEvent(gl.chain.Event):
 	          def __init__(self, sender: Address, to: Address, /): ...
 
 
-	        class TransferOccurredEvent(gl.Event):
+	        class TransferOccurredEvent(gl.chain.Event):
 	          def __init__(self, sender: Address, to: Address, /, **blob): ...
 	"""
 


### PR DESCRIPTION
## Problem

The `Event` class docstring in `runners/genlayer-py-std/src/genlayer/chain.py` shows contract examples using `gl.Event` as the base class, but `gl.Event` does not resolve at runtime — `Event` is only exported under `genlayer.chain`. A contract copying the example crashes at module load with:

```
AttributeError: module 'genlayer' has no attribute 'Event'
```

## Fix

This is **Option 1 of #327**: correct the docstring examples to the spelling that actually resolves, `gl.chain.Event` — matching what the genvm test fixtures already use (e.g. `tests/cases/stable/py/events/post_event.py`).

Changed: `runners/genlayer-py-std/src/genlayer/chain.py` (2 lines, both `class TransferOccurredEvent(gl.Event):` → `gl.chain.Event`).

The `doc/website/.../changelog-notes/v0.3.rst` occurrences of `gl.Event` were intentionally left untouched — they document the v0.2.x → v0.3.0 migration and deliberately show the old spelling as the "before".

If the team prefers option 2 (exporting `Event` at top level so `gl.Event` becomes valid), feel free to close this in favor of that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the `TransferOccurredEvent` example to use the proper qualified event class reference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->